### PR TITLE
fix(KAN-5): corrige mensaje de error al no encontrar vehículo

### DIFF
--- a/docs/KAN-5-correccion-mensaje-vehiculo.md
+++ b/docs/KAN-5-correccion-mensaje-vehiculo.md
@@ -1,0 +1,30 @@
+# Corrección del BUG KAN-5
+
+## BUG relacionado
+KAN-5 - [BUG] Corregir mensaje de error al no encontrar vehículo
+
+## Incidencia relacionada
+KAN-4 - [INC] Error al buscar vehículo inexistente en el sistema
+
+## Descripción del problema
+Se identificó que, al buscar un vehículo inexistente en el sistema de alquiler de vehículos, el sistema no mostraba un mensaje claro para el usuario.
+
+## Resultado actual
+El sistema mostraba un mensaje genérico, incorrecto o poco entendible.
+
+## Resultado esperado
+El sistema debe mostrar el siguiente mensaje:
+
+"Vehículo no encontrado. Verifique el ID ingresado."
+
+## Solución propuesta
+Se documenta la corrección del mensaje de error para que el usuario pueda identificar claramente que el vehículo buscado no existe.
+
+## Validación realizada
+- Se revisó el flujo de búsqueda de vehículo.
+- Se identificó el escenario donde el vehículo no existe.
+- Se definió un mensaje claro para el usuario.
+- Se relacionó esta corrección con el BUG KAN-5 y la incidencia KAN-4.
+
+## Estado
+Corrección lista para revisión mediante Pull Request.


### PR DESCRIPTION
## Ticket relacionado
KAN-5

## Incidencia relacionada
KAN-4

## Descripción
Se documenta la corrección del mensaje de error mostrado cuando el sistema no encuentra un vehículo registrado.

## Cambios realizados
- Se creó un archivo de evidencia para el BUG KAN-5.
- Se documentó el problema detectado.
- Se definió el mensaje esperado para el usuario.
- Se vinculó la corrección con la incidencia KAN-4.

## Pruebas realizadas
- Revisión del caso de búsqueda de vehículo inexistente.
- Validación del mensaje esperado.
- Confirmación de trazabilidad entre Jira y GitHub.

## Resultado esperado
El sistema debe mostrar el mensaje:
"Vehículo no encontrado. Verifique el ID ingresado."